### PR TITLE
Remove references to archive.org

### DIFF
--- a/CSS/gamma_targets.css
+++ b/CSS/gamma_targets.css
@@ -125,25 +125,3 @@ fieldset {outline: none; border: none;}
   1.9: 7B
   }
 
-
-
-/*
-     FILE ARCHIVED ON 15:27:46 Mar 16, 2025 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 01:19:26 Apr 17, 2025.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
-
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
-*/
-/*
-playback timings (ms):
-  captures_list: 1.701
-  exclusion.robots: 0.026
-  exclusion.robots.policy: 0.011
-  esindex: 0.014
-  cdx.remote: 24.207
-  LoadShardBlock: 97.601 (3)
-  PetaboxLoader3.datanode: 117.069 (5)
-  PetaboxLoader3.resolve: 341.403 (3)
-  load_resource: 388.596 (2)
-*/

--- a/CSS/style.0.1.4-g.css
+++ b/CSS/style.0.1.4-g.css
@@ -18,28 +18,28 @@
 /* ************************************************************************** */
 /* ************************************************************************** */
 
-@import url("https://web.archive.org/web/20250316152746cs_/https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&display=swap");
 
 /*
-@import url("https://web.archive.org/web/20250316152746cs_/https://fonts.googleapis.com/css2?family=Kanit:wght@300;400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Kanit:wght@300;400;500;600;700&display=swap");
 
 /* *****   The following only imports capitals for .dropCapSimple  ****** */
-@import url("https://web.archive.org/web/20250316152746cs_/https://fonts.googleapis.com/css2?family=Lobster+Two:ital@1&text=%20%26ABCDEFGHIJKLMNOPQRSTUVWXYZ&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Lobster+Two:ital@1&text=%20%26ABCDEFGHIJKLMNOPQRSTUVWXYZ&display=swap");
 
 /* *****   This only imports the playfair ampersand for .ampSamp  ****** */
-@import url("https://web.archive.org/web/20250316152746cs_/https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&text=%26&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&text=%26&display=swap");
 
 /* *****   Import for TABLE ONLY — Barlow CONDENSED — Limited Char Import *** 
-@import url("https://web.archive.org/web/20250316152746cs_/https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@100;200;500;600;800;900&text=0123456789%20%25%26%C2%A9%C2%A7%E2%84Lc©B&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@100;200;500;600;800;900&text=0123456789%20%25%26%C2%A9%C2%A7%E2%84Lc©B&display=swap");
 */
 
-@import url("https://web.archive.org/web/20250316152746cs_/https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@100;200;300;400;500;600;700;800;900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@100;200;300;400;500;600;700;800;900&display=swap");
 
 /* *****   Import for Code Block — Limited Char Import *****
-@import url('https://web.archive.org/web/20250316152746cs_/https://fonts.googleapis.com/css2?family=Inconsolata:wght@500;900&text=0123456789%20%23%25%26%28%29%2C%2D%2E%3A%E2%80%A2CDecSsHEXhxRGBArgbaLuminanceINlinY&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inconsolata:wght@500;900&text=0123456789%20%23%25%26%28%29%2C%2D%2E%3A%E2%80%A2CDecSsHEXhxRGBArgbaLuminanceINlinY&display=swap');
 */
 
-@import url("https://web.archive.org/web/20250316152746cs_/https://fonts.googleapis.com/css2?family=Inconsolata:wght@500;900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inconsolata:wght@500;900&display=swap");
 
 /*
 CSS rules to specify families
@@ -50,7 +50,7 @@ font-family: 'Poppins', sans-serif;
 
 
 
-@import url('https://web.archive.org/web/20250316152746cs_/https://fonts.googleapis.com/css2?family=Barlow:wght@100;200;300;400;500;600;700;800;900&family=Kanit:wght@100;200;300;400;500;600;700;800;900&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Barlow:wght@100;200;300;400;500;600;700;800;900&family=Kanit:wght@100;200;300;400;500;600;700;800;900&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200&display=swap');
 
 font-family: Barlow, Kanit , Poppins, sans-serif;
 
@@ -196,7 +196,7 @@ header.largeHeader {
   min-height: 40px;
   max-height: 150px;
   background-color: #30a;
-  background-image: url("/web/20250316152746im_/https://www.myndex.com/images/myndexhead7.png");
+  background-image: url("https://www.myndex.com/images/myndexhead7.png");
   background-position: top;
   background-size: contain;
   background-repeat: no-repeat;
@@ -206,7 +206,7 @@ header.smallHeader {
   padding:0;
   height:70px;
   background-color: #30a;
-  background-image: url("https://web.archive.org/web/20250316152746im_/https://myndex.com/images/myndexfoot7.png");
+  background-image: url("https://myndex.com/images/myndexfoot7.png");
   background-position: center;
   background-repeat: no-repeat;
 }
@@ -2068,7 +2068,7 @@ input[type="color"] {
   max-width: 94vw;
   margin: 1em auto;
   background-color: #060;
-  background-image: url("/web/20250316152746im_/https://www.myndex.com/images/textures/woodA.jpg");
+  background-image: url("https://www.myndex.com/images/textures/woodA.jpg");
   background-size: cover;
   border: 0.3em solid #440;
   /* border-color: #932 #a95555 #a34242 #932;   */
@@ -2099,7 +2099,7 @@ input[type="color"] {
   margin: 0 auto 1em;
   background-color: #62a;
   border: 0.1em solid #60c;
-  /* background-image: url('/web/20250316152746im_/https://www.myndex.com/images/textures/woodA.jpg');
+  /* background-image: url('https://www.myndex.com/images/textures/woodA.jpg');
     background-size: cover;
     border-color: #932 #a95555 #a34242 #932;   */
 }
@@ -6451,32 +6451,3 @@ footer .innerwrapper div {
   flex: 1 1 45%;
 }
 
-
-
-
-
-
-/* ************************************************************************** */
-/* **********   END OF SHEET   ********************************************** */
-/* ************************************************************************** */
-
-/*
-     FILE ARCHIVED ON 15:27:46 Mar 16, 2025 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 01:19:26 Apr 17, 2025.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
-
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
-*/
-/*
-playback timings (ms):
-  captures_list: 1.907
-  exclusion.robots: 0.027
-  exclusion.robots.policy: 0.011
-  esindex: 0.015
-  cdx.remote: 25.307
-  LoadShardBlock: 150.312 (3)
-  PetaboxLoader3.datanode: 137.234 (5)
-  PetaboxLoader3.resolve: 424.426 (3)
-  load_resource: 499.041 (2)
-*/

--- a/JS/apca-w3.js
+++ b/JS/apca-w3.js
@@ -635,23 +635,3 @@ const fontDeltaAscend = [
 
 
 }
-/*
-     FILE ARCHIVED ON 15:27:43 Mar 16, 2025 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 01:19:26 Apr 17, 2025.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
-
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
-*/
-/*
-playback timings (ms):
-  captures_list: 0.642
-  exclusion.robots: 0.033
-  exclusion.robots.policy: 0.018
-  esindex: 0.012
-  cdx.remote: 36.355
-  LoadShardBlock: 178.996 (3)
-  PetaboxLoader3.datanode: 229.991 (5)
-  PetaboxLoader3.resolve: 264.662 (3)
-  load_resource: 371.291 (2)
-*/

--- a/JS/colorparsley.js
+++ b/JS/colorparsley.js
@@ -392,23 +392,3 @@ function colorToRGB (rgba = [0,0,0,''], round = true) {
 
 
 }
-/*
-     FILE ARCHIVED ON 15:27:42 Mar 16, 2025 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 01:19:25 Apr 17, 2025.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
-
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
-*/
-/*
-playback timings (ms):
-  captures_list: 0.513
-  exclusion.robots: 0.016
-  exclusion.robots.policy: 0.007
-  esindex: 0.013
-  cdx.remote: 22.47
-  LoadShardBlock: 84.008 (3)
-  PetaboxLoader3.datanode: 142.487 (5)
-  load_resource: 353.258 (2)
-  PetaboxLoader3.resolve: 230.052 (2)
-*/

--- a/JS/iro@5
+++ b/JS/iro@5
@@ -20,23 +20,4 @@ if (!self.__WB_pmw) { self.__WB_pmw = function(obj) { this.__WB_source = obj; re
 
 
 }
-/*
-     FILE ARCHIVED ON 02:06:21 Apr 05, 2025 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 01:19:26 Apr 17, 2025.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
 
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
-*/
-/*
-playback timings (ms):
-  captures_list: 0.522
-  exclusion.robots: 0.018
-  exclusion.robots.policy: 0.008
-  esindex: 0.011
-  cdx.remote: 147.208
-  LoadShardBlock: 70.119 (3)
-  PetaboxLoader3.datanode: 83.617 (4)
-  load_resource: 366.3
-  PetaboxLoader3.resolve: 326.859
-*/


### PR DESCRIPTION
I noticed you mentioned in [your post about the new domain](https://github.com/Myndex/SAPC-APCA/discussions/135) that some things are loading slowly. It looks like this was based on a snapshot from the Internet Archive, and is hotlinking to some assets hosted on the Archive, e.g. font files, which is probably a factor. 

Note that I haven't touched the "nifty stuff you share with every site you visit" section, which, now that it's static, is also permanently listing some info about a Wayback Machine crawler. I've kept this PR strictly to changes invisible to the user.

It also seems that `myndex.com` is down as I'm writing this, meaning this change would actually stop those from loading. So perhaps bringing `myndex.com` back up blocks this – in the meantime there is some indication that the Archive ([1](https://archive.org/post/261115/hotlinking-allowed), [2](https://archive.org/post/1068520/solved-permalink-files-no-longer-allow-hotlinking)) is okay with hotlinking assets on their domain, so this would be for speed's sake.